### PR TITLE
Add MingW64 makefile

### DIFF
--- a/App.cpp
+++ b/App.cpp
@@ -84,9 +84,17 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 #else
 
+#ifdef __GNUC__
+namespace std { void __throw_bad_function_call(void) {ExitProcess(1);} }
+// entry point needs to be "C" for GNU ld...
+extern "C" void WinMainCRTStartup() {
+	app::entryPoint();
+}
+#else
 void WinMainCRTStartup() {
 	app::entryPoint();
 }
+#endif
 
 extern "C" void abort() {
 	ExitProcess(3);

--- a/Com.h
+++ b/Com.h
@@ -86,7 +86,6 @@ public:
 	}
 	
 private:
-	friend class CoPtr;
 	
 	explicit CoPtr(T* ptr) : m_ptr(ptr) {}
 	

--- a/Global.cpp
+++ b/Global.cpp
@@ -27,8 +27,11 @@
 #include <msi.h>
 #include <tlhelp32.h>
 #include <psapi.h>
+
+#ifndef NO_PROPSYS
 #include <propsys.h>
 #include <propvarutil.h>
+#endif
 
 #include <dlgs.h>
 #undef psh1
@@ -542,7 +545,7 @@ bool SetDialogBoxDirectory::tryMsOfficeFileOpen() {
 bool SetDialogBoxDirectory::tryWindowsFileOpen() {
 	// Check for standard Get(Open|Save)FileName dialog box
 	// - Must answer to CDM_GETSPEC message
-	if (SendMessage(m_hwnd, CDM_GETSPEC, 0, /* buffer= */ NULL) <= 0) {
+	if (SendMessage(m_hwnd, CDM_GETSPEC, 0, /* buffer=NULL*/ 0) <= 0) {
 		return false;
 	}
 	
@@ -605,7 +608,7 @@ void resolveLinkFile(LPCTSTR link_file, Shortcut* shortcut) {
 			return;
 		}
 	}
-	
+#ifndef __GNUC__ // Not working on MingW64...
 	// Resolve the shortcut using the IUniformResourceLocator and IPersistFile interfaces
 	CoPtr<IUniformResourceLocator> url_locator(CLSID_InternetShortcut);
 	if (url_locator) {
@@ -620,7 +623,7 @@ void resolveLinkFile(LPCTSTR link_file, Shortcut* shortcut) {
 			}
 		}
 	}
-	
+#endif
 	// Resolve the shortcut using the IShellLink and IPersistFile interfaces
 	CoPtr<IShellLink> shell_link(CLSID_ShellLink);
 	if (shell_link) {
@@ -654,6 +657,7 @@ void resolveLinkFile(LPCTSTR link_file, Shortcut* shortcut) {
 
 
 void listUwpApps(std::function<void(LPCTSTR name, LPCTSTR app_id, LPITEMIDLIST pidl)> app_callback) {
+#ifndef NO_PROPSYS
 	constexpr ULONG kMaxAppItemCount = 100;
 	constexpr size_t kMaxAppIdLength = 1000;
 	
@@ -748,6 +752,7 @@ void listUwpApps(std::function<void(LPCTSTR name, LPCTSTR app_id, LPITEMIDLIST p
 		
 		app_callback(app_name, app_id, app_pidl);
 	}
+#endif // NO_PROPSYS
 }
 
 

--- a/Intrinsics.cpp
+++ b/Intrinsics.cpp
@@ -19,6 +19,7 @@
 // Implement the intrinsices used by the application.
 // Needed to remove all dependencies to Visual C++ runtime DLLs.
 
+#include <stdint.h>
 
 extern "C" void* memset(void* dest, int value, size_t size);
 extern "C" void* memcpy(void* dest, const void* src, size_t size);

--- a/Keystroke.h
+++ b/Keystroke.h
@@ -226,7 +226,7 @@ private:
 	static void releaseKey(BYTE vk, BYTE keyboard_state[]);
 	
 	// Retrieves the name of a virtual key.
-	static void Keystroke::loadVkKeyName(BYTE vk, String* output);
+	static void loadVkKeyName(BYTE vk, String* output);
 	
 	// Name of each virtual key, empty if unknown.
 	static String s_vk_key_names[256];

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Makefile to build clavier-plus with MingW-64 GCC
+# This makefile avoids using the std lib (-nostdlib) so it is quite small.
+# All is compiled in one line with g++ with lto (link-time-optimization)
+# The generated file is around 200kB
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+CC=g++
+WR=windres
+
+LDFLAGS=-nostdlib -luuid -ladvapi32 -luser32 -lgdi32 -lcomctl32 \
+	-lcomdlg32 -lshlwapi -lole32 -lmsi -lshell32 -lkernel32 -lpsapi \
+	-Wl,-dynamicbase,-nxcompat,--no-seh \
+	-Wl,--disable-reloc-section,--disable-runtime-pseudo-reloc \
+	-Wl,--tsaware,-s -s -mwindows
+
+# 32 bit Mode (uncomment if you need and comment the 64bit mode)
+# We use PSAPI_VERSION=1 to link directly to psapi.dll
+#CFLAGS=-m32 -march=i386 -mpreferred-stack-boundary=2 -DPSAPI_VERSION=1
+#WRFLAGS=-Fpe-i386
+#LDFLAGS+=-e_WinMainCRTStartup
+
+# 64 bit Mode
+#CFLAGS=-m64 -march=x86-64
+#WRFLAGS=-Fpe-x86-64
+#LDFLAGS+=-eWinMainCRTStartup
+
+WARNINGS=-Wall -Wno-unknown-pragmas -Wno-multichar -Wno-strict-aliasing
+
+# We need to use UNICODE and std=c++17
+# Also there are a lot of flags necessary for the -nostdlib
+# flag (/NODEFAULTLIBS equivalent)
+CFLAGS+=-std=c++17 -Os -mno-stack-arg-probe -momit-leaf-frame-pointer \
+	-fomit-frame-pointer -fno-stack-check -fno-stack-protector \
+	-fno-threadsafe-statics -fno-use-cxa-get-exception-ptr \
+	-fno-access-control -fno-enforce-eh-specs -fno-nonansi-builtins \
+	-fnothrow-opt -fno-optional-diags -fno-use-cxa-atexit -fno-exceptions\
+	-fno-dwarf2-cfi-asm -fno-asynchronous-unwind-tables \
+	-fno-extern-tls-init -fno-rtti -Wnoexcept \
+	-D_UNICODE -DUNICODE -U_DEBUG -UDEBUG -DNO_PROPSYS $(WARNINGS)
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+default: clavier.exe
+
+clavier.exe: rez.o App.cpp App.h Dialogs.cpp Dialogs.h Global.cpp \
+	Global.h I18n.cpp I18n.h Intrinsics.cpp Keystroke.cpp Keystroke.h \
+	MyString.h Shortcut.cpp Shortcut.h StdAfx.cpp StdAfx.h
+	$(CC) *.cpp rez.o -o clavier.exe $(CFLAGS) $(LDFLAGS) -flto
+
+rez.o: Clavier.rc Resource.h Clavier.manifest App.ico Add.ico
+	$(WR) $(WRFLAGS) Clavier.rc rez.o
+
+clean:
+	rm clavier.exe rez.o

--- a/StdAfx.h
+++ b/StdAfx.h
@@ -80,7 +80,11 @@ inline bool reportFailedAssert(const char* message) {
 }
 
 #else
+#ifdef __GNUC__
+#define assert(expression)
+#else
 #define assert(expression)  __noop
+#endif
 #endif
 
 // Memory leaks detection
@@ -101,9 +105,11 @@ inline bool reportFailedAssert(const char* message) {
 #error Non-Unicode is no longer supported
 #endif
 
-
+#ifdef __GNUC__
+#define SUPPRESS_WARNING(code)
+#else
 #define SUPPRESS_WARNING(code)  __pragma(warning(suppress: code))
-
+#endif
 #define toBool(value)  ((value) != 0)
 #define UNUSED(name)  SUPPRESS_WARNING(4100) name
 


### PR DESCRIPTION
First I would like to thanks you for this program, it is quite helpful for me!
I wanted to make my own build (I like to have control on the binary), so I tried to build with MinGW64 and encountered very few problems, so I decided to share them.

The code just needed a few adjustments to build on MinGW64 some are actually corrections.
The main limitation is that mingw64 does not have a complete header+lib for the PROPSYS.DLL file. nor for the `CLSID_InternetShortcut` I just made a define in the source to supress inclusion of PROPSYS stuff.

hopefully MinGW64 gets his headers and lib files updated at some point...

I think supporting more than one compiler is useful for people to be able to easily help with development as well as giving more options to the users.

Fixes (ctd = C++17)
* A class is its always its own friend (see CoPtr).
* SendMessage cannot have its last parameter to be NULL, it must integer-type (tolerated with proper gcc parameter, but better fix it).
* a function declaration inside a class must not specify classname::, it is invalid in c++ and strangely accepted by VC++, not gcc.
